### PR TITLE
fix: lower slug length limit to 220 for Vercel prerender-fallback suffix

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -10,7 +10,7 @@ export async function generateStaticParams() {
     const posts = await getPostsForSitemap();
     return posts
         .filter((p) => p.slug)
-        .filter((p) => encodeURIComponent(p.slug!).length <= 240)
+        .filter((p) => encodeURIComponent(p.slug!).length <= 220)
         .map((p) => ({ slug: encodeURIComponent(p.slug!) }));
 }
 import { JsonLdScript } from "@/components/seo/JsonLdScript";


### PR DESCRIPTION
Vercel 빌드 시 .rsc.prerender-fallback.rsc (27자) 확장자로 255바이트 초과 240 → 220으로 조정